### PR TITLE
Fix using camera in newer Android distributions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,17 @@
                 android:name="android.content.SyncAdapter"
                 android:resource="@xml/syncadapter" />
         </service>
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="ro.code4.monitorizarevot.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <!-- ressource file to create -->
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths">
+            </meta-data>
+        </provider>
         <!-- TODO if it's a a StubProvider why is it here in the first place? -->
         <provider
             android:authorities="@string/authorities"

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="observation_images_demo" path="Android/data/pl.org.epf.monitorujwybory.demo/files/Pictures" />
+    <external-path name="observation_images_pl2018" path="Android/data/pl.org.epf.monitorujwybory.pl2018/files/Pictures" />
+    <external-path name="observation_images_live" path="Android/data/pl.org.epf.monitorujwybory.live/files/Pictures" />
+    <external-path name="observation_images_ro2015" path="Android/data/ro.code4.monitorizarevot.ro2015/files/Pictures" />
+</paths>

--- a/mediapicker/src/main/java/vn/tungdx/mediapicker/utils/MediaUtils.java
+++ b/mediapicker/src/main/java/vn/tungdx/mediapicker/utils/MediaUtils.java
@@ -9,6 +9,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.MediaPlayer;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Images;
@@ -52,12 +53,16 @@ public class MediaUtils {
      * @return
      * @throws IOException
      */
-    public static File createDefaultImageFile() throws IOException {
+    public static File createDefaultImageFile(Context context) throws IOException {
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss",
                 Locale.getDefault()).format(new Date());
-        String imageFileName = "JPEG_" + timeStamp + ".jpg";
-        File storageDir = Environment
-                .getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+        String imageFileName = "IMG_" + timeStamp + ".jpg";
+        File storageDir = null;
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            storageDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        } else {
+            storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+        }
         if (!storageDir.exists()) {
             storageDir.mkdirs();
         }


### PR DESCRIPTION
Fix camera error by using FileProvider to save files from camera on Android version >= 7.